### PR TITLE
Fix model_name so that it can send urls for :time_entry

### DIFF
--- a/lib/base.rb
+++ b/lib/base.rb
@@ -5,7 +5,7 @@ module Beetil
     class << self
 
       def model_name
-        @_model_name ||= ActiveModel::Name.new(self).human
+        @_model_name ||= ActiveModel::Name.new(self).demodulize.underscore
       end
 
       def table_name

--- a/lib/client/time_entry.rb
+++ b/lib/client/time_entry.rb
@@ -1,12 +1,4 @@
 module Beetil
   class TimeEntry < Beetil::Base
-    # Beetil::Base has a buggy implementation and cannot handle two word classes properly, until that's fixed...
-    def self.model_name
-      @_model_name = "time_entry"
-    end
-
-    def self.table_name
-      @_table_name = "time_entries"
-    end
   end
 end


### PR DESCRIPTION
model_name should handle classes with two words such as Beetil::TimeEntr...y, and should be transformed into :time_entry
