### PR TITLE
Upgrade httparty used to newer version

### DIFF
--- a/beetil.gemspec
+++ b/beetil.gemspec
@@ -9,7 +9,7 @@ spec = Gem::Specification.new do |s|
   s.email = ["luke@beetil.com"]
 
   s.add_dependency 'activemodel'
-  s.add_dependency 'httparty', '~> 0.7.8'
+  s.add_dependency 'httparty', '~> 0.8.1'
   s.add_dependency 'hashie',   '~> 1.1.0'
 
   s.add_development_dependency 'rspec',       '~> 2.6.0'


### PR DESCRIPTION
The current version of httparty used uses a very old version of crack, and I get this error in Ruby 1.9.2. Upgrading to the latest httparty solved it (it does not use crack anymore)

```
/Users/kuahyeow/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:148:in `parse': couldn't parse YAML at line 1 column 370 (Psych::SyntaxError)
    from /Users/kuahyeow/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:148:in `parse_stream'
    from /Users/kuahyeow/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:119:in `parse'
    from /Users/kuahyeow/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/psych.rb:106:in `load'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/crack-0.1.8/lib/crack/json.rb:12:in `parse'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/parser.rb:116:in `json'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/parser.rb:136:in `parse_supported_format'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/parser.rb:103:in `parse'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/parser.rb:66:in `call'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/request.rb:217:in `parse_response'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/request.rb:189:in `handle_response'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty/request.rb:71:in `perform'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty.rb:390:in `perform_request'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/gems/httparty-0.7.8/lib/httparty.rb:358:in `post'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/bundler/gems/beetil-87ff34b0c365/lib/base.rb:45:in `perform_beetil_request'
    from /Users/kuahyeow/.rvm/gems/ruby-1.9.2-p290@harvester/bundler/gems/beetil-87ff34b0c365/lib/base.rb:31:in `create'
    from play.rb:38:in `block in <main>'
    from play.rb:37:in `each'
    from play.rb:37:in `<main>'
```
